### PR TITLE
feat: change the button color to cyan

### DIFF
--- a/app/src/main/res/drawable/onboarding_button_background.xml
+++ b/app/src/main/res/drawable/onboarding_button_background.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="@color/onboarding_button_cyan" />
+    <solid android:color="#00E5FF" />
     <corners android:radius="30dp" />
-    <stroke
-        android:width="2dp"
-        android:color="#00ACC1" />
 </shape>
 

--- a/app/src/main/res/layout/fragment_on_boarding3.xml
+++ b/app/src/main/res/layout/fragment_on_boarding3.xml
@@ -105,7 +105,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="32dp"
-        android:background="@drawable/onboarding_button_background"
+        android:backgroundTint="#00E5FF"
         android:fontFamily="@font/happy_monkey"
         android:minWidth="200dp"
         android:minHeight="60dp"
@@ -116,6 +116,7 @@
         android:textColor="@color/black"
         android:textSize="28sp"
         android:textStyle="bold"
+        app:cornerRadius="30dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/textView18" />


### PR DESCRIPTION
This pull request updates the appearance of the onboarding button on the third onboarding screen to simplify its background and styling. The main changes involve removing the custom drawable background and instead using direct color and corner radius properties in the layout file.

**UI Styling Updates:**

* The button's background is now set using `android:backgroundTint` with the color `#00E5FF` directly in `fragment_on_boarding3.xml`, instead of referencing the `onboarding_button_background` drawable.
* The button now uses the `app:cornerRadius` property to achieve rounded corners, replacing the previous use of a drawable with a corner radius.

**Drawable Simplification:**

* The `onboarding_button_background.xml` drawable was simplified by removing the stroke and changing the solid color to `#00E5FF`, but it is no longer used as the button background.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changed the onboarding button on screen 3 to cyan (#00E5FF) with 30dp rounded corners. Switched from a custom drawable to android:backgroundTint and app:cornerRadius in the layout to simplify styling.

<sup>Written for commit dd72f4bcf3bec706062fb4050a2b3f1e4d671d47. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated onboarding button background color to cyan
  * Removed button border stroke for a cleaner appearance
  * Increased button corner radius for softer, rounded edges

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->