### PR TITLE
feat: fix color inconsistency in card color \n changing it to white

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-12-21T05:50:11.887430Z">
+        <DropdownSelection timestamp="2025-12-21T05:56:03.036794Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/billy/.android/avd/Medium_Phone.avd" />
+              <DeviceId pluginId="PhysicalDevice" identifier="serial=55050DLAQ000AK" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/app/src/main/res/layout/item_child_card_provider.xml
+++ b/app/src/main/res/layout/item_child_card_provider.xml
@@ -7,6 +7,7 @@
     android:layout_marginEnd="8dp"
     android:layout_marginTop="4dp"
     android:layout_marginBottom="4dp"
+    app:cardBackgroundColor="#FFFFFF"
     app:cardCornerRadius="8dp"
     app:cardElevation="4dp">
 

--- a/app/src/main/res/layout/item_child_card_simple.xml
+++ b/app/src/main/res/layout/item_child_card_simple.xml
@@ -4,6 +4,7 @@
     android:layout_width="280dp"
     android:layout_height="wrap_content"
     android:layout_margin="8dp"
+    app:cardBackgroundColor="#FFFFFF"
     app:cardCornerRadius="8dp"
     app:cardElevation="4dp">
 

--- a/app/src/main/res/layout/item_child_zone_children.xml
+++ b/app/src/main/res/layout/item_child_zone_children.xml
@@ -4,6 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_margin="8dp"
+    app:cardBackgroundColor="#FFFFFF"
     app:cardCornerRadius="8dp"
     app:cardElevation="4dp">
 

--- a/app/src/main/res/layout/item_child_zone_dashboard.xml
+++ b/app/src/main/res/layout/item_child_zone_dashboard.xml
@@ -4,6 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_margin="8dp"
+    app:cardBackgroundColor="#FFFFFF"
     app:cardCornerRadius="8dp"
     app:cardElevation="4dp">
 

--- a/app/src/main/res/layout/item_dashboard_tile.xml
+++ b/app/src/main/res/layout/item_dashboard_tile.xml
@@ -4,6 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_margin="8dp"
+    app:cardBackgroundColor="#FFFFFF"
     app:cardCornerRadius="8dp"
     app:cardElevation="4dp">
 

--- a/app/src/main/res/layout/item_incident.xml
+++ b/app/src/main/res/layout/item_incident.xml
@@ -4,6 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_margin="8dp"
+    app:cardBackgroundColor="#FFFFFF"
     app:cardCornerRadius="8dp"
     app:cardElevation="4dp">
 

--- a/app/src/main/res/layout/item_notification.xml
+++ b/app/src/main/res/layout/item_notification.xml
@@ -4,6 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_margin="8dp"
+    app:cardBackgroundColor="#FFFFFF"
     app:cardCornerRadius="8dp"
     app:cardElevation="2dp">
 

--- a/app/src/main/res/layout/item_schedule_date.xml
+++ b/app/src/main/res/layout/item_schedule_date.xml
@@ -4,6 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_margin="8dp"
+    app:cardBackgroundColor="#FFFFFF"
     app:cardCornerRadius="8dp"
     app:cardElevation="2dp">
 

--- a/app/src/main/res/layout/item_schedule_time.xml
+++ b/app/src/main/res/layout/item_schedule_time.xml
@@ -4,6 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_margin="8dp"
+    app:cardBackgroundColor="#FFFFFF"
     app:cardCornerRadius="8dp"
     app:cardElevation="2dp">
 

--- a/app/src/main/res/layout/item_zone_change.xml
+++ b/app/src/main/res/layout/item_zone_change.xml
@@ -4,6 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_margin="8dp"
+    app:cardBackgroundColor="#FFFFFF"
     app:cardCornerRadius="8dp"
     app:cardElevation="4dp">
 


### PR DESCRIPTION
This pull request makes consistent visual improvements to various card-based UI components in the app by explicitly setting the card background color to white. Additionally, there is an update to the deployment target configuration, switching from an emulator to a physical device.

**UI consistency improvements:**

* Added `app:cardBackgroundColor="#FFFFFF"` to multiple layout files to ensure all card views have a consistent white background:
  - `item_child_card_provider.xml`
  - `item_child_card_simple.xml`
  - `item_child_zone_children.xml`
  - `item_child_zone_dashboard.xml`
  - `item_dashboard_tile.xml`
  - `item_incident.xml`
  - `item_notification.xml`
  - `item_schedule_date.xml`
  - `item_schedule_time.xml`
  - `item_zone_change.xml`

**Development environment update:**

* Changed the default deployment target in `.idea/deploymentTargetSelector.xml` from an Android emulator to a connected physical device.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set all CardView backgrounds to white to fix inconsistent card colors and ensure a uniform look across the app. Also updated the default deployment target to a connected physical device.

- **Bug Fixes**
  - Explicitly set app:cardBackgroundColor to #FFFFFF on all card layouts (child cards, dashboard tiles, incidents, notifications, schedules, zone change).

<sup>Written for commit 1023d7acd0bca8044f5dea8128d345883e591903. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated card styling across multiple screens to use consistent white backgrounds, enhancing visual uniformity throughout the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->