### PR TITLE
Feat/cleaning

### DIFF
--- a/app/src/main/java/com/example/myapplication/dailycheckin/CheckInEntry.java
+++ b/app/src/main/java/com/example/myapplication/dailycheckin/CheckInEntry.java
@@ -12,12 +12,14 @@ public class CheckInEntry {
     String activityLimits;
     double coughWheezeLevel = -1;
     ArrayList<String> triggers = new ArrayList<>();
+    long timestamp; // Timestamp to allow multiple entries per day
     public CheckInEntry(String username, boolean nightWaking, String activityLimits, double coughWheezeLevel, ArrayList<String>triggers) {
         this.username = username;
         this.nightWaking = nightWaking;
         this.activityLimits = activityLimits;
         this.coughWheezeLevel = coughWheezeLevel;
         this.triggers = triggers;
+        this.timestamp = System.currentTimeMillis(); // Set timestamp to current time
     }
     public CheckInEntry() {
 
@@ -52,6 +54,12 @@ public class CheckInEntry {
     }
     public void setTriggers(ArrayList<String> triggers) {
         this.triggers = triggers;
+    }
+    public long getTimestamp() {
+        return this.timestamp;
+    }
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
     }
 
     /*@Override public boolean equals (Object o) {

--- a/app/src/main/java/com/example/myapplication/inhaler/ChildInhalerLogs.java
+++ b/app/src/main/java/com/example/myapplication/inhaler/ChildInhalerLogs.java
@@ -143,12 +143,15 @@ public class ChildInhalerLogs extends AppCompatActivity {
         String encodedID = FirebaseKeyEncoder.encode(ID);
         
         // Attach realtime listener for rescue logs
+        // Check encoded path first (current standard), then raw path for backward compatibility
         rescueLogRef = UserManager.mDatabase.child("RescueLogManager").child(encodedID);
         rescueLogListener = new ValueEventListener() {
             @Override
             public void onDataChange(DataSnapshot snapshot) {
                 ArrayList<RescueLog> logs = new ArrayList<>();
+                boolean foundData = false;
                 if (snapshot.exists()) {
+                    foundData = true;
                     for (DataSnapshot s : snapshot.getChildren()) {
                         RescueLog record = s.getValue(RescueLog.class);
                         if (record != null) {
@@ -157,11 +160,49 @@ public class ChildInhalerLogs extends AppCompatActivity {
                     }
                     Log.d(TAG, "Loaded " + logs.size() + " rescue logs with realtime updates");
                 }
-                // Clear and rebuild rescue log views
-                LinearLayout rescueLayout = findViewById(R.id.linearlayout1);
-                if (rescueLayout != null) {
-                    rescueLayout.removeAllViews();
-                    addRescueLogs(logs);
+                
+                // If no data found at encoded path and encoded != raw, check raw path for backward compatibility
+                if (!foundData && !encodedID.equals(ID)) {
+                    Log.d(TAG, "Checking raw ID path for rescue logs (backward compatibility): " + ID);
+                    DatabaseReference rawRescueLogRef = UserManager.mDatabase.child("RescueLogManager").child(ID);
+                    rawRescueLogRef.addListenerForSingleValueEvent(new ValueEventListener() {
+                        @Override
+                        public void onDataChange(DataSnapshot rawSnapshot) {
+                            if (rawSnapshot.exists()) {
+                                for (DataSnapshot s : rawSnapshot.getChildren()) {
+                                    RescueLog record = s.getValue(RescueLog.class);
+                                    if (record != null) {
+                                        logs.add(record);
+                                    }
+                                }
+                                Log.d(TAG, "Loaded " + logs.size() + " rescue logs from raw path (backward compatibility)");
+                            }
+                            // Clear and rebuild rescue log views
+                            LinearLayout rescueLayout = findViewById(R.id.linearlayout1);
+                            if (rescueLayout != null) {
+                                rescueLayout.removeAllViews();
+                                addRescueLogs(logs);
+                            }
+                        }
+
+                        @Override
+                        public void onCancelled(DatabaseError error) {
+                            Log.e(TAG, "Error loading rescue logs from raw path", error.toException());
+                            // Clear and rebuild rescue log views
+                            LinearLayout rescueLayout = findViewById(R.id.linearlayout1);
+                            if (rescueLayout != null) {
+                                rescueLayout.removeAllViews();
+                                addRescueLogs(logs);
+                            }
+                        }
+                    });
+                } else {
+                    // Clear and rebuild rescue log views
+                    LinearLayout rescueLayout = findViewById(R.id.linearlayout1);
+                    if (rescueLayout != null) {
+                        rescueLayout.removeAllViews();
+                        addRescueLogs(logs);
+                    }
                 }
             }
 
@@ -173,12 +214,15 @@ public class ChildInhalerLogs extends AppCompatActivity {
         rescueLogRef.addValueEventListener(rescueLogListener);
         
         // Attach realtime listener for controller logs
+        // Check encoded path first (current standard), then raw path for backward compatibility
         controllerLogRef = UserManager.mDatabase.child("ControllerLogManager").child(encodedID);
         controllerLogListener = new ValueEventListener() {
             @Override
             public void onDataChange(DataSnapshot snapshot) {
                 ArrayList<ControllerLog> logs = new ArrayList<>();
+                boolean foundData = false;
                 if (snapshot.exists()) {
+                    foundData = true;
                     for (DataSnapshot s : snapshot.getChildren()) {
                         ControllerLog record = s.getValue(ControllerLog.class);
                         if (record != null) {
@@ -187,11 +231,49 @@ public class ChildInhalerLogs extends AppCompatActivity {
                     }
                     Log.d(TAG, "Loaded " + logs.size() + " controller logs with realtime updates");
                 }
-                // Clear and rebuild controller log views
-                LinearLayout controllerLayout = findViewById(R.id.linearlayout2);
-                if (controllerLayout != null) {
-                    controllerLayout.removeAllViews();
-                    addControllerLogs(logs);
+                
+                // If no data found at encoded path and encoded != raw, check raw path for backward compatibility
+                if (!foundData && !encodedID.equals(ID)) {
+                    Log.d(TAG, "Checking raw ID path for controller logs (backward compatibility): " + ID);
+                    DatabaseReference rawControllerLogRef = UserManager.mDatabase.child("ControllerLogManager").child(ID);
+                    rawControllerLogRef.addListenerForSingleValueEvent(new ValueEventListener() {
+                        @Override
+                        public void onDataChange(DataSnapshot rawSnapshot) {
+                            if (rawSnapshot.exists()) {
+                                for (DataSnapshot s : rawSnapshot.getChildren()) {
+                                    ControllerLog record = s.getValue(ControllerLog.class);
+                                    if (record != null) {
+                                        logs.add(record);
+                                    }
+                                }
+                                Log.d(TAG, "Loaded " + logs.size() + " controller logs from raw path (backward compatibility)");
+                            }
+                            // Clear and rebuild controller log views
+                            LinearLayout controllerLayout = findViewById(R.id.linearlayout2);
+                            if (controllerLayout != null) {
+                                controllerLayout.removeAllViews();
+                                addControllerLogs(logs);
+                            }
+                        }
+
+                        @Override
+                        public void onCancelled(DatabaseError error) {
+                            Log.e(TAG, "Error loading controller logs from raw path", error.toException());
+                            // Clear and rebuild controller log views
+                            LinearLayout controllerLayout = findViewById(R.id.linearlayout2);
+                            if (controllerLayout != null) {
+                                controllerLayout.removeAllViews();
+                                addControllerLogs(logs);
+                            }
+                        }
+                    });
+                } else {
+                    // Clear and rebuild controller log views
+                    LinearLayout controllerLayout = findViewById(R.id.linearlayout2);
+                    if (controllerLayout != null) {
+                        controllerLayout.removeAllViews();
+                        addControllerLogs(logs);
+                    }
                 }
             }
 

--- a/app/src/main/java/com/example/myapplication/inhaler/ControllerLogModel.java
+++ b/app/src/main/java/com/example/myapplication/inhaler/ControllerLogModel.java
@@ -57,17 +57,52 @@ public class ControllerLogModel {
                     @Override
                     public void onDataChange(@NonNull DataSnapshot snapshot) {
                         HashMap<String, ControllerLog> map = new HashMap<>();
-                        for (DataSnapshot s : snapshot.getChildren()) {
-                            String date = s.getKey();
-                            ControllerLog record = s.getValue(ControllerLog.class);
-                            map.put(date, record);
+                        boolean foundData = false;
+                        if (snapshot.exists()) {
+                            foundData = true;
+                            for (DataSnapshot s : snapshot.getChildren()) {
+                                String date = s.getKey();
+                                ControllerLog record = s.getValue(ControllerLog.class);
+                                map.put(date, record);
+                            }
                         }
-                        if (callback != null){
-                            callback.onComplete(map);
+                        
+                        // If no data found at encoded path and encoded != raw, check raw path for backward compatibility
+                        if (!foundData && !encodedUsername.equals(username)) {
+                            UserManager.mDatabase.child("ControllerLogManager").child(username)
+                                    .addListenerForSingleValueEvent(new ValueEventListener() {
+                                        @Override
+                                        public void onDataChange(@NonNull DataSnapshot rawSnapshot) {
+                                            if (rawSnapshot.exists()) {
+                                                for (DataSnapshot s : rawSnapshot.getChildren()) {
+                                                    String date = s.getKey();
+                                                    ControllerLog record = s.getValue(ControllerLog.class);
+                                                    map.put(date, record);
+                                                }
+                                            }
+                                            if (callback != null){
+                                                callback.onComplete(map);
+                                            }
+                                        }
+                                        @Override
+                                        public void onCancelled(@NonNull DatabaseError error) {
+                                            if (callback != null){
+                                                callback.onComplete(map);
+                                            }
+                                        }
+                                    });
+                        } else {
+                            if (callback != null){
+                                callback.onComplete(map);
+                            }
                         }
                     }
                     @Override
-                    public void onCancelled(@NonNull DatabaseError error) {}
+                    public void onCancelled(@NonNull DatabaseError error) {
+                        if (callback != null){
+                            callback.onComplete(new HashMap<>());
+                        }
+                    }
                 });
     }
 
@@ -107,17 +142,55 @@ public class ControllerLogModel {
                     @Override
                     public void onDataChange(@NonNull DataSnapshot snapshot) {
                         HashMap<String, ControllerLog> map = new HashMap<>();
-                        for (DataSnapshot s : snapshot.getChildren()) {
-                            String date = s.getKey();
-                            ControllerLog record = s.getValue(ControllerLog.class);
-                            map.put(date, record);
+                        boolean foundData = false;
+                        if (snapshot.exists()) {
+                            foundData = true;
+                            for (DataSnapshot s : snapshot.getChildren()) {
+                                String date = s.getKey();
+                                ControllerLog record = s.getValue(ControllerLog.class);
+                                map.put(date, record);
+                            }
                         }
-                        if (callback != null){
-                            callback.onComplete(map);
+                        
+                        // If no data found at encoded path and encoded != raw, check raw path for backward compatibility
+                        if (!foundData && !encodedUsername.equals(username)) {
+                            UserManager.mDatabase.child("ControllerLogManager").child(username)
+                                    .orderByKey()
+                                    .startAt(begin)
+                                    .endAt(end)
+                                    .addListenerForSingleValueEvent(new ValueEventListener() {
+                                        @Override
+                                        public void onDataChange(@NonNull DataSnapshot rawSnapshot) {
+                                            if (rawSnapshot.exists()) {
+                                                for (DataSnapshot s : rawSnapshot.getChildren()) {
+                                                    String date = s.getKey();
+                                                    ControllerLog record = s.getValue(ControllerLog.class);
+                                                    map.put(date, record);
+                                                }
+                                            }
+                                            if (callback != null){
+                                                callback.onComplete(map);
+                                            }
+                                        }
+                                        @Override
+                                        public void onCancelled(@NonNull DatabaseError error) {
+                                            if (callback != null){
+                                                callback.onComplete(map);
+                                            }
+                                        }
+                                    });
+                        } else {
+                            if (callback != null){
+                                callback.onComplete(map);
+                            }
                         }
                     }
                     @Override
-                    public void onCancelled(@NonNull DatabaseError error) {}
+                    public void onCancelled(@NonNull DatabaseError error) {
+                        if (callback != null){
+                            callback.onComplete(new HashMap<>());
+                        }
+                    }
                 });
     }
 }

--- a/app/src/main/java/com/example/myapplication/inhaler/RescueLogModel.java
+++ b/app/src/main/java/com/example/myapplication/inhaler/RescueLogModel.java
@@ -50,17 +50,52 @@ public class RescueLogModel {
                     @Override
                     public void onDataChange(@NonNull DataSnapshot snapshot) {
                         HashMap<String, RescueLog> map = new HashMap<>();
-                        for (DataSnapshot s : snapshot.getChildren()) {
-                            String date = s.getKey();
-                            RescueLog record = s.getValue(RescueLog.class);
-                            map.put(date, record);
+                        boolean foundData = false;
+                        if (snapshot.exists()) {
+                            foundData = true;
+                            for (DataSnapshot s : snapshot.getChildren()) {
+                                String date = s.getKey();
+                                RescueLog record = s.getValue(RescueLog.class);
+                                map.put(date, record);
+                            }
                         }
-                        if (callback != null){
-                            callback.onComplete(map);
+                        
+                        // If no data found at encoded path and encoded != raw, check raw path for backward compatibility
+                        if (!foundData && !encodedUsername.equals(username)) {
+                            UserManager.mDatabase.child("RescueLogManager").child(username)
+                                    .addListenerForSingleValueEvent(new ValueEventListener() {
+                                        @Override
+                                        public void onDataChange(@NonNull DataSnapshot rawSnapshot) {
+                                            if (rawSnapshot.exists()) {
+                                                for (DataSnapshot s : rawSnapshot.getChildren()) {
+                                                    String date = s.getKey();
+                                                    RescueLog record = s.getValue(RescueLog.class);
+                                                    map.put(date, record);
+                                                }
+                                            }
+                                            if (callback != null){
+                                                callback.onComplete(map);
+                                            }
+                                        }
+                                        @Override
+                                        public void onCancelled(@NonNull DatabaseError error) {
+                                            if (callback != null){
+                                                callback.onComplete(map);
+                                            }
+                                        }
+                                    });
+                        } else {
+                            if (callback != null){
+                                callback.onComplete(map);
+                            }
                         }
                     }
                     @Override
-                    public void onCancelled(@NonNull DatabaseError error) {}
+                    public void onCancelled(@NonNull DatabaseError error) {
+                        if (callback != null){
+                            callback.onComplete(new HashMap<>());
+                        }
+                    }
                 });
     }
 
@@ -100,17 +135,55 @@ public class RescueLogModel {
                     @Override
                     public void onDataChange(@NonNull DataSnapshot snapshot) {
                         HashMap<String, RescueLog> map = new HashMap<>();
-                        for (DataSnapshot s : snapshot.getChildren()) {
-                            String date = s.getKey();
-                            RescueLog record = s.getValue(RescueLog.class);
-                            map.put(date, record);
+                        boolean foundData = false;
+                        if (snapshot.exists()) {
+                            foundData = true;
+                            for (DataSnapshot s : snapshot.getChildren()) {
+                                String date = s.getKey();
+                                RescueLog record = s.getValue(RescueLog.class);
+                                map.put(date, record);
+                            }
                         }
-                        if (callback != null){
-                            callback.onComplete(map);
+                        
+                        // If no data found at encoded path and encoded != raw, check raw path for backward compatibility
+                        if (!foundData && !encodedUsername.equals(username)) {
+                            UserManager.mDatabase.child("RescueLogManager").child(username)
+                                    .orderByKey()
+                                    .startAt(begin)
+                                    .endAt(end)
+                                    .addListenerForSingleValueEvent(new ValueEventListener() {
+                                        @Override
+                                        public void onDataChange(@NonNull DataSnapshot rawSnapshot) {
+                                            if (rawSnapshot.exists()) {
+                                                for (DataSnapshot s : rawSnapshot.getChildren()) {
+                                                    String date = s.getKey();
+                                                    RescueLog record = s.getValue(RescueLog.class);
+                                                    map.put(date, record);
+                                                }
+                                            }
+                                            if (callback != null){
+                                                callback.onComplete(map);
+                                            }
+                                        }
+                                        @Override
+                                        public void onCancelled(@NonNull DatabaseError error) {
+                                            if (callback != null){
+                                                callback.onComplete(map);
+                                            }
+                                        }
+                                    });
+                        } else {
+                            if (callback != null){
+                                callback.onComplete(map);
+                            }
                         }
                     }
                     @Override
-                    public void onCancelled(@NonNull DatabaseError error) {}
+                    public void onCancelled(@NonNull DatabaseError error) {
+                        if (callback != null){
+                            callback.onComplete(new HashMap<>());
+                        }
+                    }
                 });
     }
 }

--- a/app/src/main/java/com/example/myapplication/safety/IncidentHistoryActivity.java
+++ b/app/src/main/java/com/example/myapplication/safety/IncidentHistoryActivity.java
@@ -2,6 +2,8 @@ package com.example.myapplication.safety;
 
 import android.os.Bundle;
 import android.content.Intent;
+import android.os.Handler;
+import android.os.Looper;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -23,13 +25,13 @@ import com.example.myapplication.utils.FirebaseKeyEncoder;
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.DatabaseReference;
-import com.google.firebase.database.Query;
 import com.google.firebase.database.ValueEventListener;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -44,9 +46,17 @@ public class IncidentHistoryActivity extends AppCompatActivity {
     private String parentId;
     private String childId;
     
-    // Realtime listener references
-    private DatabaseReference incidentRef;
-    private ValueEventListener incidentListener;
+    // Realtime listener references for both encoded and raw paths
+    private DatabaseReference incidentRefEncoded;
+    private DatabaseReference incidentRefRaw;
+    private ValueEventListener incidentListenerEncoded;
+    private ValueEventListener incidentListenerRaw;
+    // Separate result maps for encoded and raw paths (encoded takes precedence)
+    private HashMap<String, TriageIncident> encodedResults = new HashMap<>();
+    private HashMap<String, TriageIncident> rawResults = new HashMap<>();
+    // Handler for debouncing UI updates and ensuring main thread execution
+    private Handler mainHandler = new Handler(Looper.getMainLooper());
+    private Runnable pendingUpdate = null;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -112,118 +122,194 @@ public class IncidentHistoryActivity extends AppCompatActivity {
             return;
         }
         
-        // Detach existing listener first to prevent duplicates
+        // Detach existing listeners first to prevent duplicates
         detachIncidentListener();
         
+        // Clear result maps
+        encodedResults.clear();
+        rawResults.clear();
+        
         String encodedChildId = FirebaseKeyEncoder.encode(childId);
-        incidentRef = UserManager.mDatabase
+        incidentRefEncoded = UserManager.mDatabase
                 .child("users")
                 .child(parentId)
                 .child("children")
                 .child(encodedChildId)
                 .child("incidents");
 
-        // Use direct listener instead of orderByChild query to avoid index requirements
         // Use addValueEventListener for realtime updates similar to personalBest
-        // Check encoded path first (current standard), then raw path for backward compatibility
-        incidentListener = new ValueEventListener() {
+        // Attach listener to encoded path (current standard)
+        incidentListenerEncoded = new ValueEventListener() {
             @Override
             public void onDataChange(DataSnapshot snapshot) {
-                incidents.clear();
-                boolean foundData = false;
-                if (snapshot.exists()) {
-                    foundData = true;
-                    for (DataSnapshot child : snapshot.getChildren()) {
-                        TriageIncident incident = child.getValue(TriageIncident.class);
-                        if (incident != null) {
-                            incidents.add(incident);
+                // Clear and rebuild encoded path results
+                synchronized (encodedResults) {
+                    encodedResults.clear();
+                    if (snapshot.exists()) {
+                        int totalEntries = 0;
+                        for (DataSnapshot child : snapshot.getChildren()) {
+                            totalEntries++;
+                            TriageIncident incident = child.getValue(TriageIncident.class);
+                            if (incident != null) {
+                                // Use timestamp as key to handle duplicates
+                                String key = String.valueOf(incident.getTimestamp());
+                                encodedResults.put(key, incident);
+                                Log.d(TAG, "Added incident from encoded path: timestamp=" + incident.getTimestamp());
+                            }
                         }
+                        Log.d(TAG, "Loaded " + encodedResults.size() + " incidents from encoded path (total: " + totalEntries + ", realtime update)");
+                    } else {
+                        Log.d(TAG, "No incidents found at encoded Firebase path: " + incidentRefEncoded.toString());
                     }
-                    // Sort by timestamp descending (newest first)
-                    Collections.sort(incidents, (a, b) -> Long.compare(b.getTimestamp(), a.getTimestamp()));
-                    Log.d(TAG, "Loaded " + incidents.size() + " incidents from Firebase path: " + incidentRef.toString());
-                    Log.d(TAG, "Incident history loaded with realtime updates");
-                } else {
-                    Log.d(TAG, "No incidents found at Firebase path: " + incidentRef.toString());
                 }
                 
-                // If no data found at encoded path and encoded != raw, check raw path for backward compatibility
-                if (!foundData && !encodedChildId.equals(childId)) {
-                    Log.d(TAG, "Checking raw childId path for incidents (backward compatibility): " + childId);
-                    DatabaseReference rawIncidentRef = UserManager.mDatabase
-                            .child("users")
-                            .child(parentId)
-                            .child("children")
-                            .child(childId)
-                            .child("incidents");
-                    
-                    rawIncidentRef.addListenerForSingleValueEvent(new ValueEventListener() {
-                        @Override
-                        public void onDataChange(DataSnapshot rawSnapshot) {
-                            if (rawSnapshot.exists()) {
-                                for (DataSnapshot child : rawSnapshot.getChildren()) {
-                                    TriageIncident incident = child.getValue(TriageIncident.class);
-                                    if (incident != null) {
-                                        incidents.add(incident);
-                                    }
-                                }
-                                // Sort by timestamp descending (newest first)
-                                Collections.sort(incidents, (a, b) -> Long.compare(b.getTimestamp(), a.getTimestamp()));
-                                Log.d(TAG, "Loaded " + incidents.size() + " incidents from raw path (backward compatibility): " + rawIncidentRef.toString());
-                            }
-                            adapter.notifyDataSetChanged();
-                            
-                            if (incidents.isEmpty()) {
-                                textViewEmpty.setVisibility(View.VISIBLE);
-                                recyclerViewIncidents.setVisibility(View.GONE);
-                            } else {
-                                textViewEmpty.setVisibility(View.GONE);
-                                recyclerViewIncidents.setVisibility(View.VISIBLE);
-                            }
-                        }
-
-                        @Override
-                        public void onCancelled(DatabaseError error) {
-                            Log.e(TAG, "Error loading incidents from raw Firebase path: " + rawIncidentRef.toString(), error.toException());
-                            adapter.notifyDataSetChanged();
-                            
-                            if (incidents.isEmpty()) {
-                                textViewEmpty.setVisibility(View.VISIBLE);
-                                recyclerViewIncidents.setVisibility(View.GONE);
-                            } else {
-                                textViewEmpty.setVisibility(View.GONE);
-                                recyclerViewIncidents.setVisibility(View.VISIBLE);
-                            }
-                        }
-                    });
-                } else {
-                    adapter.notifyDataSetChanged();
-                    
-                    if (incidents.isEmpty()) {
-                        textViewEmpty.setVisibility(View.VISIBLE);
-                        recyclerViewIncidents.setVisibility(View.GONE);
-                    } else {
-                        textViewEmpty.setVisibility(View.GONE);
-                        recyclerViewIncidents.setVisibility(View.VISIBLE);
-                    }
-                }
+                // Merge and display (encoded takes precedence) - debounced on main thread
+                scheduleMergeAndDisplay();
             }
 
             @Override
             public void onCancelled(DatabaseError error) {
-                Log.e(TAG, "Error loading incidents from Firebase path: " + incidentRef.toString(), error.toException());
+                Log.e(TAG, "Error loading incidents from encoded Firebase path: " + incidentRefEncoded.toString(), error.toException());
             }
         };
         
-        incidentRef.addValueEventListener(incidentListener);
+        incidentRefEncoded.addValueEventListener(incidentListenerEncoded);
+        
+        // If encoded != raw, also attach listener to raw path for backward compatibility
+        if (!encodedChildId.equals(childId)) {
+            Log.d(TAG, "Attaching realtime listener to raw childId path for backward compatibility: " + childId);
+            incidentRefRaw = UserManager.mDatabase
+                    .child("users")
+                    .child(parentId)
+                    .child("children")
+                    .child(childId)
+                    .child("incidents");
+            
+            incidentListenerRaw = new ValueEventListener() {
+                @Override
+                public void onDataChange(DataSnapshot snapshot) {
+                    // Clear and rebuild raw path results
+                    synchronized (rawResults) {
+                        rawResults.clear();
+                        if (snapshot.exists()) {
+                            int totalEntries = 0;
+                            for (DataSnapshot child : snapshot.getChildren()) {
+                                totalEntries++;
+                                TriageIncident incident = child.getValue(TriageIncident.class);
+                                if (incident != null) {
+                                    // Use timestamp as key to handle duplicates
+                                    String key = String.valueOf(incident.getTimestamp());
+                                    rawResults.put(key, incident);
+                                    Log.d(TAG, "Added incident from raw path: timestamp=" + incident.getTimestamp());
+                                }
+                            }
+                            Log.d(TAG, "Loaded " + rawResults.size() + " incidents from raw path (total: " + totalEntries + ", realtime update, backward compatibility)");
+                        } else {
+                            Log.d(TAG, "No incidents found at raw Firebase path: " + incidentRefRaw.toString());
+                        }
+                    }
+                    
+                    // Merge and display (encoded takes precedence) - debounced on main thread
+                    scheduleMergeAndDisplay();
+                }
+
+                @Override
+                public void onCancelled(DatabaseError error) {
+                    Log.e(TAG, "Error loading incidents from raw Firebase path: " + incidentRefRaw.toString(), error.toException());
+                }
+            };
+            
+            incidentRefRaw.addValueEventListener(incidentListenerRaw);
+        } else {
+            Log.d(TAG, "Encoded childId equals raw childId, only attaching listener to encoded path");
+        }
+    }
+    
+    /**
+     * Schedule merge and display with debouncing to prevent rapid UI updates
+     * when both listeners fire simultaneously
+     */
+    private void scheduleMergeAndDisplay() {
+        // Cancel any pending update
+        if (pendingUpdate != null) {
+            mainHandler.removeCallbacks(pendingUpdate);
+        }
+        
+        // Schedule new update with small delay to debounce rapid updates
+        pendingUpdate = new Runnable() {
+            @Override
+            public void run() {
+                mergeAndDisplayResults();
+            }
+        };
+        mainHandler.postDelayed(pendingUpdate, 100); // 100ms debounce
+    }
+    
+    private void mergeAndDisplayResults() {
+        // Ensure this runs on main thread for UI updates
+        if (Looper.myLooper() != Looper.getMainLooper()) {
+            mainHandler.post(() -> mergeAndDisplayResults());
+            return;
+        }
+        
+        // Merge encoded and raw results (encoded takes precedence for duplicates)
+        HashMap<String, TriageIncident> merged = new HashMap<>();
+        synchronized (rawResults) {
+            merged.putAll(rawResults);
+        }
+        synchronized (encodedResults) {
+            merged.putAll(encodedResults); // Encoded overwrites raw for same timestamps
+        }
+        
+        // Convert to list and sort by timestamp descending (newest first)
+        incidents.clear();
+        incidents.addAll(merged.values());
+        Collections.sort(incidents, (a, b) -> Long.compare(b.getTimestamp(), a.getTimestamp()));
+        
+        Log.d(TAG, "Merged results: " + incidents.size() + " total incidents (encoded: " + encodedResults.size() + ", raw: " + rawResults.size() + ")");
+        Log.d(TAG, "Incident history loaded with realtime updates and full persistence support");
+        
+        adapter.notifyDataSetChanged();
+        
+        if (incidents.isEmpty()) {
+            textViewEmpty.setVisibility(View.VISIBLE);
+            recyclerViewIncidents.setVisibility(View.GONE);
+        } else {
+            textViewEmpty.setVisibility(View.GONE);
+            recyclerViewIncidents.setVisibility(View.VISIBLE);
+        }
     }
     
     private void detachIncidentListener() {
-        if (incidentRef != null && incidentListener != null) {
-            incidentRef.removeEventListener(incidentListener);
-            incidentListener = null;
+        // Cancel any pending UI updates
+        if (pendingUpdate != null) {
+            mainHandler.removeCallbacks(pendingUpdate);
+            pendingUpdate = null;
         }
-        incidentRef = null;
+        
+        // Detach encoded path listener
+        if (incidentRefEncoded != null && incidentListenerEncoded != null) {
+            incidentRefEncoded.removeEventListener(incidentListenerEncoded);
+            incidentListenerEncoded = null;
+            Log.d(TAG, "Detached encoded path listener");
+        }
+        incidentRefEncoded = null;
+        
+        // Detach raw path listener
+        if (incidentRefRaw != null && incidentListenerRaw != null) {
+            incidentRefRaw.removeEventListener(incidentListenerRaw);
+            incidentListenerRaw = null;
+            Log.d(TAG, "Detached raw path listener");
+        }
+        incidentRefRaw = null;
+        
+        // Clear result maps
+        synchronized (encodedResults) {
+            encodedResults.clear();
+        }
+        synchronized (rawResults) {
+            rawResults.clear();
+        }
     }
 
     private static class IncidentAdapter extends RecyclerView.Adapter<IncidentAdapter.ViewHolder> {

--- a/app/src/main/res/layout/filter_check_in_history_symptoms.xml
+++ b/app/src/main/res/layout/filter_check_in_history_symptoms.xml
@@ -203,17 +203,14 @@
         android:id="@+id/go_to_filter_date"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="20dp"
         android:layout_marginTop="48dp"
-        android:layout_marginEnd="301dp"
+        android:layout_marginEnd="16dp"
         android:backgroundTint="#000000"
         android:onClick="goBackToDateButton"
         android:text="Back"
         android:textColor="#FFFFFF"
         app:cornerRadius="5dp"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
     <CheckBox


### PR DESCRIPTION
This pull request updates the daily check-in feature to support multiple entries per day by using timestamps as unique keys, improves backward compatibility with older data, and enhances the robustness of database read/write operations. The changes also introduce better handling for real-time listeners and UI updates in the check-in history view.

**Support for multiple check-ins per day and improved data handling:**

* Added a `timestamp` field to the `CheckInEntry` class, set to the current time when a new entry is created, and provided getter/setter methods for it. This enables multiple check-ins per day by uniquely identifying each entry with a timestamp. [[1]](diffhunk://#diff-ccba4cdca78da0d32482dd5b2a202897ce9c0be911f1d65509c59a3dbcae2a35R15-R22) [[2]](diffhunk://#diff-ccba4cdca78da0d32482dd5b2a202897ce9c0be911f1d65509c59a3dbcae2a35R58-R63)
* Modified the `WriteIntoDB` method in `CheckInModel.java` to use the timestamp as the database key instead of the date, ensuring that multiple entries for the same day are stored without overwriting each other.

**Backward compatibility and robust database reads:**

* Updated `readFromDB` methods to handle both new (timestamp-keyed) and old (date-keyed) entries, ensuring backward compatibility. If no data is found under the encoded username, the system also checks the raw username path. The results are returned as a map keyed by timestamp or date as appropriate. [[1]](diffhunk://#diff-fb0df7bdb7be32f6ce461684f68b4393cdc12926f58490910b29549214f5bec5R73-R126) [[2]](diffhunk://#diff-fb0df7bdb7be32f6ce461684f68b4393cdc12926f58490910b29549214f5bec5R149-R233)

**Enhancements to check-in history view:**

* Refactored `ViewCheckInHistory.java` to support separate real-time listeners and result maps for encoded and raw database paths, with encoded data taking precedence. Introduced a handler for debouncing UI updates and ensuring main thread execution, improving UI responsiveness and correctness.
* Added necessary imports for date formatting, locale handling, and main-thread operations to support the above changes. [[1]](diffhunk://#diff-e22e4f6a26b65b8e4ae40f7fce57982dc1f551fc9fbe052fdfa8d24df0a70ef2R10-R11) [[2]](diffhunk://#diff-e22e4f6a26b65b8e4ae40f7fce57982dc1f551fc9fbe052fdfa8d24df0a70ef2R34-R39)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable multiple daily check-ins by saving entries with timestamp keys and make reads/listeners backward-compatible. Improves history and reporting screens, adds UI debouncing, and fixes a back button overlap.

- **New Features**
  - Add timestamp to CheckInEntry and persist using timestamp keys to allow multiple entries per day.
  - Update history view to better reflect multiple check-ins with more accurate date formatting.

- **Bug Fixes**
  - Backward compatibility: fall back to raw IDs when encoded paths have no data across pefReadings, inhaler logs, controller/rescue logs, incident history, provider reports, and PEF history.
  - Read methods handle both timestamp-keyed and date-keyed data without breaking older entries.
  - Stabilize real-time listeners and debounce UI updates on the main thread to prevent flicker and race conditions.
  - Fix Back button layout to avoid overlapping other UI elements.

<sup>Written for commit b7d950c54689840be109258052b274836365f76d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Check-in entries now include precise timestamps for improved record tracking.

* **Bug Fixes**
  * Improved data loading reliability for historical records, health metrics, and incident reports.
  * Enhanced backward-compatibility handling to ensure complete data retrieval.

* **UI/UX Improvements**
  * Optimized filter layout for better usability.
  * Refined real-time data synchronization for smoother updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->