### PR TITLE
Feat/cardview

### DIFF
--- a/app/src/main/res/layout/activity_provider_report_generator.xml
+++ b/app/src/main/res/layout/activity_provider_report_generator.xml
@@ -89,12 +89,11 @@
                 android:textSize="16sp"
                 android:textStyle="bold"  android:textColor="#000000"/>
 
-            <LinearLayout
-                android:id="@+id/linearLayoutSharedItems"
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recyclerViewSharedItems"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
-                android:orientation="vertical"
                 android:visibility="gone" />
 
             <TextView
@@ -115,29 +114,11 @@
                 android:textSize="16sp"
                 android:textStyle="bold"  android:textColor="#000000"/>
 
-            <TextView
-                android:id="@+id/textViewRescueFrequency"
-                android:layout_width="wrap_content"
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recyclerViewReportSummary"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:text="Rescue Frequency: Loading..."
-                android:textSize="14sp"  android:textColor="#000000"/>
-
-            <TextView
-                android:id="@+id/textViewAdherence"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:text="Controller Adherence: Loading..."
-                android:textSize="14sp"  android:textColor="#000000"/>
-
-            <TextView
-                android:id="@+id/textViewSymptomBurden"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:text="Symptom Burden: Loading..."
-                android:textSize="14sp"  android:textColor="#000000"/>
+                android:layout_marginTop="8dp" />
 
             <TextView
                 android:layout_width="wrap_content"

--- a/app/src/main/res/layout/item_check_in_history.xml
+++ b/app/src/main/res/layout/item_check_in_history.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="8dp"
+    app:cardBackgroundColor="#FFFFFF"
+    app:cardCornerRadius="8dp"
+    app:cardElevation="4dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp"
+        android:background="@color/white">
+
+        <TextView
+            android:id="@+id/textViewDate"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Date"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            android:textColor="#000000"/>
+
+        <TextView
+            android:id="@+id/textViewLoggedBy"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="Logged by:"
+            android:textSize="14sp"
+            android:textColor="#000000"/>
+
+        <TextView
+            android:id="@+id/textViewNightWaking"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text=""
+            android:textSize="14sp"
+            android:textColor="#000000"/>
+
+        <TextView
+            android:id="@+id/textViewActivityLimits"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text=""
+            android:textSize="14sp"
+            android:textColor="#000000"/>
+
+        <TextView
+            android:id="@+id/textViewCoughWheeze"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text=""
+            android:textSize="14sp"
+            android:textColor="#000000"/>
+
+        <TextView
+            android:id="@+id/textViewTriggers"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text=""
+            android:textSize="14sp"
+            android:textColor="#000000"/>
+    </LinearLayout>
+</androidx.cardview.widget.CardView>
+

--- a/app/src/main/res/layout/item_provider_sharing_status.xml
+++ b/app/src/main/res/layout/item_provider_sharing_status.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="8dp"
+    android:layout_marginEnd="8dp"
+    android:layout_marginTop="4dp"
+    android:layout_marginBottom="4dp"
+    app:cardBackgroundColor="#FFFFFF"
+    app:cardCornerRadius="8dp"
+    app:cardElevation="2dp">
+
+    <TextView
+        android:id="@+id/textViewSharedItem"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="12dp"
+        android:text="Shared Item"
+        android:textSize="14sp"
+        android:textColor="#4CAF50" />
+
+</androidx.cardview.widget.CardView>
+

--- a/app/src/main/res/layout/item_report_summary.xml
+++ b/app/src/main/res/layout/item_report_summary.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="8dp"
+    android:layout_marginEnd="8dp"
+    android:layout_marginTop="4dp"
+    android:layout_marginBottom="4dp"
+    app:cardBackgroundColor="#FFFFFF"
+    app:cardCornerRadius="8dp"
+    app:cardElevation="2dp">
+
+    <TextView
+        android:id="@+id/textViewSummaryItem"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="12dp"
+        android:text="Summary Item"
+        android:textSize="14sp"
+        android:textColor="#000000" />
+
+</androidx.cardview.widget.CardView>
+

--- a/app/src/main/res/layout/view_history.xml
+++ b/app/src/main/res/layout/view_history.xml
@@ -1,16 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-<ScrollView xmlns:app="http://schemas.android.com/apk/res-auto"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:background="@color/white">
-
-<androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    tools:layout_height="1000dp">
+    android:layout_height="match_parent"
+    android:background="@color/white">
 
     <TextView
         android:id="@+id/view_history_title"
@@ -24,20 +18,8 @@
         android:textSize="48sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"  android:textColor="#000000"/>
-
-    <TextView
-        android:id="@+id/display_history"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="48dp"
-        android:layout_marginEnd="337dp"
-        android:text="No entries match these filters."
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.03"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/view_history_title"  android:textColor="#000000"/>
+        app:layout_constraintTop_toTopOf="parent"
+        android:textColor="#000000"/>
 
     <Button
         android:id="@+id/refilter_button"
@@ -50,7 +32,8 @@
         android:text="Select New Filters"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"  android:textColor="#000000"/>
+        app:layout_constraintTop_toTopOf="parent"
+        android:textColor="#000000"/>
 
     <Button
         android:id="@+id/export_pdf_button"
@@ -62,6 +45,30 @@
         android:text="Export to PDF"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/refilter_button"
-        app:layout_constraintTop_toTopOf="parent"  android:textColor="#000000"/>
+        app:layout_constraintTop_toTopOf="parent"
+        android:textColor="#000000"/>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerViewCheckIns"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="16dp"
+        android:padding="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/view_history_title" />
+
+    <TextView
+        android:id="@+id/textViewEmpty"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="No entries match these filters."
+        android:textSize="18sp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:textColor="#000000"/>
 </androidx.constraintlayout.widget.ConstraintLayout>
-</ScrollView>

--- a/app/src/main/res/layout/view_history.xml
+++ b/app/src/main/res/layout/view_history.xml
@@ -4,7 +4,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/white">
+    android:background="#99D9EA">
 
     <TextView
         android:id="@+id/view_history_title"


### PR DESCRIPTION
This pull request refactors the way check-in histories and provider report summaries are displayed in the app, replacing static `TextView` elements and `LinearLayout` lists with dynamic `RecyclerView` components and adapters. This improves scalability, maintainability, and the user experience for displaying lists of items such as check-in entries, shared items, and summary data.

The most important changes are:

**Daily Check-in History UI Refactor:**
- Replaced the single `TextView` history display with a `RecyclerView` (`recyclerViewCheckIns`) and introduced a `CheckInAdapter` to dynamically show a list of check-in entries, including formatting and conditional display of symptoms and triggers based on user type. [[1]](diffhunk://#diff-e22e4f6a26b65b8e4ae40f7fce57982dc1f551fc9fbe052fdfa8d24df0a70ef2L45-R56) [[2]](diffhunk://#diff-e22e4f6a26b65b8e4ae40f7fce57982dc1f551fc9fbe052fdfa8d24df0a70ef2L73-R88) [[3]](diffhunk://#diff-e22e4f6a26b65b8e4ae40f7fce57982dc1f551fc9fbe052fdfa8d24df0a70ef2L373-R406) [[4]](diffhunk://#diff-e22e4f6a26b65b8e4ae40f7fce57982dc1f551fc9fbe052fdfa8d24df0a70ef2R505-R596)
- Added an empty state message (`textViewEmpty`) that is shown when there are no check-in entries to display. [[1]](diffhunk://#diff-e22e4f6a26b65b8e4ae40f7fce57982dc1f551fc9fbe052fdfa8d24df0a70ef2L45-R56) [[2]](diffhunk://#diff-e22e4f6a26b65b8e4ae40f7fce57982dc1f551fc9fbe052fdfa8d24df0a70ef2L373-R406)

**Provider Report Generator UI Refactor:**
- Replaced the vertical `LinearLayout` (`linearLayoutSharedItems`) for shared items with a `RecyclerView` (`recyclerViewSharedItems`) and created a `SharingStatusAdapter` for displaying shared report items. [[1]](diffhunk://#diff-779034167134ff370ce405467adc69cb7e12eada85cc757a684757e8014dfd54L71-R86) [[2]](diffhunk://#diff-779034167134ff370ce405467adc69cb7e12eada85cc757a684757e8014dfd54L138-R160) [[3]](diffhunk://#diff-779034167134ff370ce405467adc69cb7e12eada85cc757a684757e8014dfd54L190-L195) [[4]](diffhunk://#diff-779034167134ff370ce405467adc69cb7e12eada85cc757a684757e8014dfd54L221-R238) [[5]](diffhunk://#diff-30a3fb7b9b460a8c2b350cb0f31d824e86bdc458cff0532c45c147de9ea19e2aL92-L97) [[6]](diffhunk://#diff-779034167134ff370ce405467adc69cb7e12eada85cc757a684757e8014dfd54R1524-R1607)
- Removed individual `TextView` elements for report summary metrics (rescue frequency, adherence, symptom burden) and replaced them with a `RecyclerView` (`recyclerViewReportSummary`) using a new `ReportSummaryAdapter`. [[1]](diffhunk://#diff-779034167134ff370ce405467adc69cb7e12eada85cc757a684757e8014dfd54L71-R86) [[2]](diffhunk://#diff-779034167134ff370ce405467adc69cb7e12eada85cc757a684757e8014dfd54L138-R160) [[3]](diffhunk://#diff-30a3fb7b9b460a8c2b350cb0f31d824e86bdc458cff0532c45c147de9ea19e2aL118-R121) [[4]](diffhunk://#diff-779034167134ff370ce405467adc69cb7e12eada85cc757a684757e8014dfd54L627-R641) [[5]](diffhunk://#diff-779034167134ff370ce405467adc69cb7e12eada85cc757a684757e8014dfd54R1524-R1607)

**Supporting Layout Changes:**
- Updated the relevant XML layout files to remove obsolete `TextView` and `LinearLayout` elements and add the new `RecyclerView` components for both shared items and report summaries. [[1]](diffhunk://#diff-30a3fb7b9b460a8c2b350cb0f31d824e86bdc458cff0532c45c147de9ea19e2aL92-L97) [[2]](diffhunk://#diff-30a3fb7b9b460a8c2b350cb0f31d824e86bdc458cff0532c45c147de9ea19e2aL118-R121)

These changes make the UI more flexible and better suited for displaying dynamic lists of data.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced static list UIs with RecyclerViews and adapters for check‑in history and provider reports. Lists are now dynamic, show empty states, and are easier to maintain.

- **Refactors**
  - Daily Check-in History: added RecyclerView (recyclerViewCheckIns) with CheckInAdapter, sorted by timestamp, empty state (textViewEmpty), and conditional symptom/trigger visibility based on user type.
  - Provider Report Generator: shared items now use RecyclerView (SharingStatusAdapter); summary metrics moved to RecyclerView (ReportSummaryAdapter) with loading placeholders and a “no sharing” empty state.
  - Layouts: added item_check_in_history.xml, item_provider_sharing_status.xml, item_report_summary.xml; updated view_history.xml and activity_provider_report_generator.xml to remove obsolete views and add RecyclerViews; changed history screen background to cyan.

<sup>Written for commit 408dae2b7f384735cadc10a9d0260d7bf84e865b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Reorganized check-in history display as a scrollable, card-based list with empty-state messaging when no data is available.
  * Enhanced report views with improved layout and card-based presentation of shared items and summary statistics.
  * Refined historical data presentation across the app with consistent, structured card components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->